### PR TITLE
lint workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,17 @@ name: Sanity checks
 on: [push]
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ./actionlint -color
+        shell: bash
+
   pre-commit:
     runs-on: ubuntu-latest
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/test.yml
@@ -7,6 +7,17 @@ on:
       - "**"
 {% raw %}
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ./actionlint -color
+        shell: bash
+
   lint-cruft:
     name: Check if automatic project update was successful
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's easy to screw up the workflows. Let's validate them beforehand :)

---
It's also possible to integrate it into `pre-commit`, but the downside of that approach is that `actionlint` needs to be [manually installed](https://github.com/rhysd/actionlint/blob/main/docs/usage.md#pre-commit) on the system. Using docker would be an option, but I don't think it's  a good idea to force everyone to have docker installed.