### PR TITLE
fix: run pyupgrade from installed dev-dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         types: [python]
       - id: pyupgrade
         name: pyupgrade
-        entry: pyupgrade --py37-plus
+        entry: poetry run pyupgrade --py37-plus
         language: system
         types: [python]
       - id: mypy


### PR DESCRIPTION
`pre-commit` should use the installed version as there might be a version mismatch otherwise or `pyupgrade` might not be available at all.