### PR TITLE
fix: autoupdate is broken due to changed GHA behaviour

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Check if there are changes
         id: changes
-        uses: UnicornGlobal/has-changes-action@v1.0.11
+        run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
 
       - name: apply additional changes and fixes
         if: steps.changes.outputs.changed == 1

--- a/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "::set-output name=changed::$(git status --porcelain | wc -l)"
 
       - name: apply additional changes and fixes
-        if: steps.changes.outputs.changed == 1
+        if: steps.changes.outputs.changed > 0
         run: |
           poetry lock --no-update  # add new dependencies
           poetry install
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get template versions
         id: get_versions
-        if: steps.changes.outputs.changed == 1
+        if: steps.changes.outputs.changed > 0
         shell: bash
         run: |
           CURRENT_VERSION=$(git show HEAD:.cruft.json | jello -r "_['commit'][:8]")
@@ -44,7 +44,7 @@ jobs:
 
       - name: Get changelog
         id: get_changelog
-        if: steps.changes.outputs.changed == 1
+        if: steps.changes.outputs.changed > 0
         shell: bash
         run: |
           TEMPLATE=$(jello -r "_['template']" < .cruft.json)


### PR DESCRIPTION
The auto update does not work anymore. Unfortunately, the pipeline is still reported as successfully... thus we have to manually update all repositories.
<img width="731" alt="Screenshot 2022-05-25 at 16 15 12" src="https://user-images.githubusercontent.com/318650/170270754-d4bdc0fe-a49a-457f-9fc9-35199947dcec.png">


This solution is much much simpler and has not external dependency. See https://github.com/UnicornGlobal/has-changes-action/issues/5 for more information.