### PR TITLE
Pin actionlint to 1.6.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.21
         shell: bash
       - name: Check workflow files
         run: ./actionlint -color
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: 3.9
       - run: python -m pip install cookiecutter poetry
-      - run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.21
       - name: Generate project
         run: |
           cookiecutter --config-file tests/context.yaml --no-input .

--- a/{{cookiecutter.project_slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.21
         shell: bash
       - name: Check workflow files
         run: ./actionlint -color


### PR DESCRIPTION
1.6.22 requires a number of changes in our workflow yamls, e.g. have to get rid of set-output.