### PR TITLE
Update mkdocstrings

### DIFF
--- a/{{cookiecutter.project_slug}}/mkdocs.yml
+++ b/{{cookiecutter.project_slug}}/mkdocs.yml
@@ -31,5 +31,6 @@ plugins:
           rendering:
             show_signature_annotations: true
             show_source: true
+            show_submodules: true
       watch:
         - src/{{ cookiecutter.package_name }}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -43,7 +43,7 @@ flake8-debugger = "*"
 flake8-eradicate = "*"
 flake8-logging-format = "*"
 isort = "*"
-mkdocstrings = "*"
+mkdocstrings = {version = ">=0.18", extras = ["python"]}
 mkdocs-material = "*"
 mypy = "*"
 pep8-naming = "*"


### PR DESCRIPTION
They apparently flipped the show_submodules default value to False at some point. Also, they stopped shipping the Python handler so it needs to be explicitly added as requirement.