### PR TITLE
Update `actions/setup-python` version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: python -m pip install pre-commit
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: python -m pip install cookiecutter pytest pyyaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: python -m pip install cookiecutter poetry

--- a/{{cookiecutter.project_slug}}/.github/actions/python-poetry-env/action.yml
+++ b/{{cookiecutter.project_slug}}/.github/actions/python-poetry-env/action.yml
@@ -10,7 +10,7 @@ outputs: {}
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{inputs.python-version}}
     - name: Install poetry

--- a/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cookiecutter.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
Hi! 👋 

Since `actions/setup-python@v2` has some deprecation warnings, the version can be upgraded to `v4`. More info:

- https://github.com/actions/setup-python/issues/526
- https://github.com/joaopalmeiro/cloack/actions/runs/3629587864/jobs/6121966272