### PR TITLE
Quote site name

### DIFF
--- a/{{cookiecutter.project_slug}}/mkdocs.yml
+++ b/{{cookiecutter.project_slug}}/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: {{ cookiecutter.project_name }}
+site_name: "{{ cookiecutter.project_name }}"
 repo_url: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}
 
 theme:


### PR DESCRIPTION
A project name starting with a special YAML character causes the file to have an invalid syntax. Quoting the value solves this.